### PR TITLE
Fixed unit in ADA rewards chart

### DIFF
--- a/src/components/ChartTrackAda/index.js
+++ b/src/components/ChartTrackAda/index.js
@@ -23,7 +23,7 @@ const ChartTrackXray = ({ history, epochCut }) => {
         backgroundColor: ["#355aeb"],
         hoverBackgroundColor: ["#355aeb"],
         borderColor: ["#355aeb"],
-        postfix: "XRAY",
+        postfix: "ADA",
       },
     ],
   }


### PR DESCRIPTION
The unit in the ADA epoch rewards chart is showing "XRAY" as the unit so changed to "ADA".